### PR TITLE
Make GS Writing Guides guide more general

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,6 @@
-= Writing a Getting Started Guide image:https://travis-ci.org/{repo-path}.svg?branch=master["Build Status", link="https://travis-ci.org/{repo-path}"]
+= How to Write Gradle Guides image:https://travis-ci.org/{repo-path}.svg?branch=master["Build Status", link="https://travis-ci.org/{repo-path}"]
 
-This guide walks you through the process of writing a new _Getting Started Guide_ for inclusion at https://guides.gradle.org/[guides.gradle.org]. These guides are short, step-by-step tutorials that focus on a single, minimal task. The idea is to take readers from nothing to a working example, while pointing out further reading if they want to learn more.
-
-== What you'll build
-
-Once you and the Gradle Guides team have agreed on a new guide, you will work on a fork of a skeleton Getting Started Guide repository, develop the guide using Asciidoc, and finally submit a Pull Request once your guide is ready for review.
+This guide walks you through the process of writing a new _Gradle Guide_ for inclusion at https://guides.gradle.org/[guides.gradle.org]. These guides can take different forms—such as short, step-by-step tutorials or longer, more discussion-oriented pieces—but the process for writing and contributing them is the same.
 
 == What you'll need
 
@@ -16,7 +12,7 @@ Once you and the Gradle Guides team have agreed on a new guide, you will work on
 
 == Create a GitHub issue
 
-The first step in creating a new Getting Started Guide that is listed on the Gradle Guides site involves submitting a proposal for the new guide to the https://github.com/gradle/guides[gradle/guides] GitHub repository. This is so that we, the Gradle Guides team, can work with you to determine the most appropriate subject and scope for the guide.
+The first step in creating a new Gradle Guide is to submit a proposal to the https://github.com/gradle/guides[gradle/guides] GitHub repository. This is so that we, the Gradle Guides team, can work with you to determine the most appropriate subject, form and scope for the guide.
 
 To submit your proposal:
 
@@ -24,11 +20,17 @@ To submit your proposal:
  - Add a basic outline for the proposed guide, i.e. section headings
  - Engage with the Gradle Guides team through this issue to nail down the final form of the guide
 
-Once the proposal has been accepted, the Gradle Guides team will https://github.com/gradle/guides/blob/master/README.md[create a new GitHub repository] for your guide. You won't be able to commit directly to that repository, but that's not a problem as you will be using the standard fork and pull request work flow.
+You don't have to specify which form the guide should take in the initial proposal, but if you do, please express your preference as one of the following:
+
+ - Short, step-by-step tutorial (Getting Started Guide)
+ - Long-form tutorial
+ - Discussion about a single topic (topical guide)
+
+Once the proposal has been accepted, the Gradle Guides team will https://github.com/gradle/guides/blob/master/README.md[create a new GitHub repository] for your guide. You won't be able to commit directly to that repository, but that's not a problem as you will be using the standard fork and pull request workflow.
 
 == Fork and clone the repository
 
-The Gradle Guides team will add a link to your guide's repository in the issue you created in the previous step. As soon as you see that link, you can:
+When your guide's repository is ready, you'll find a link to it in the issue created by you in the previous step. You should then:
 
  - https://help.github.com/articles/fork-a-repo/[Fork the repository]
  - Clone your fork
@@ -37,11 +39,11 @@ That's it! You're now ready to work on the content for your new guide using the 
 
 == Render and view your guide locally
 
-You already have everything you need to render the guide from Asciidoc into HTML and view the result. Run the following commands in the guide project directory to process the guide source and open the resulting HTML file:
+The project provides everything you need to generate the HTML version of your guide and view the result. Just run the following commands in the guide's root directory:
 
 ----
-$ ./gradlew build                                                            <1>
-$ open build/html5/index.html                                                <2>
+$ ./gradlew build                    <1>
+$ open build/html5/index.html        <2>
 ----
 <1> Run Gradle (via the Gradle Wrapper) to generate HTML from your guide's Asciidoc sources
 <2> Open the generated HTML file in your system's default browser
@@ -50,21 +52,21 @@ At this point, you should have opened an HTML page that has a title and some sec
 
 == Get familiar with your guide's structure and contents
 
-The structure of a Getting Started Guide repository is very simple, consisting of just two basic components:
+The structure of a Gradle Guide repository is very simple, consisting of just two basic components:
 
  1. An Asciidoc source file
- 2. A Gradle build to process them into HTML (and later to publish them to GitHub Pages)
+ 2. A Gradle build to process it into HTML (and later, publish it to GitHub Pages)
 
 The file you'll interact with most as a guide author is `README.adoc`, but it's useful to know what the other files and directories are for as well. The following listing walks through each of the top-level directory entries:
 
 ----
 .
-├── README.adoc                                                              <1>
-├── build                                                                    <2>
-├── build.gradle                                                             <3>
-├── gradle                                                                   <4>
-├── gradlew                                                                  <5>
-└── gradlew.bat                                                              <6>
+├── README.adoc                      <1>
+├── build                            <2>
+├── build.gradle                     <3>
+├── gradle                           <4>
+├── gradlew                          <5>
+└── gradlew.bat                      <6>
 ----
 <1> Asciidoc source for the guide
 <2> Output directory for the build, where generated HTML for the guide can be found
@@ -77,14 +79,14 @@ Now you're ready to work on your new guide's content.
 
 == Write your guide
 
-Now you can use your favorite editor to flesh out your new guide in `README.adoc`!
+Asciidoc is a pure ASCII text format, so you can use any text editor or IDE to work on `README.adoc`. Many of them have support for Asciidoc syntax highlighting, which makes things easier. Once you've decided on an editor, just open the file and get writing!
 
-As you work on the main content of the guide, we recommend that you read the https://github.com/gradle-guides/style-guide/blob/master/README.adoc[style guide] and work through a few of the existing https://guides.gradle.org/[Getting Started Guides] if you haven't done so already.
+As you work on the main content of the guide, we recommend that you read the associated https://github.com/gradle-guides/style-guide/blob/master/README.adoc[style guide] and read through a few of the existing https://guides.gradle.org/[Gradle Guides] if you haven't done so already.
 
 [TIP]
 .New to Asciidoc?
 ====
-Refer to the http://asciidoctor.org/docs/user-manual/[Asciidoctor user manual] while writing and you'll master the basics in no time. There is also a http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[quick reference for syntax] that's particularly useful when you just want to know the syntax for something specific.
+Refer to the http://asciidoctor.org/docs/user-manual/[Asciidoctor User Manual] while writing and you'll master the basics in no time. There is also a http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[quick reference for syntax] that's particularly useful when you just want to know the syntax for something specific.
 ====
 
 When you want to preview your changes, simply regenerate your guide's HTML with the following build command:
@@ -95,14 +97,25 @@ Then open or refresh `build/html5/index.html` in your browser. It's as simple as
 
 == Send a pull request
 
-Once you're happy with your guide, the final step is to submit it through a https://help.github.com/articles/creating-a-pull-request-from-a-fork/[Pull Request]. Your guide well then enter a review process, during which changes may be requested. If that happens, simply make the changes locally and push them to your fork. The Pull Request will be updated automatically.
+Writing is usually an iterative process. You write a draft, it gets reviewed, you do a second draft, and so on. That's why we recommend that you submit your guide for review as soon as you want feedback. To do so, initiate a https://help.github.com/articles/creating-a-pull-request-from-a-fork/[pull request] when you're ready.
 
-You'll be able to find your guide from the https://guides.gradle.org/[Gradle Guides site] soon after the pull request is accepted and merged.
+Your guide enters the review process at this point. Each step of a review involves either feedback (as comments) or edits (as commits) depending on the current stage of the process. That's why it's important for you to specify what type of review you want. Should the Gradle Guides team treat the current version of your guide as a first draft or something that's ready to be published? Do you simply want feedback on the structure and overall tone, or do you want the team to check for and fix spelling and grammar issues? You don't have to be too specific and the team will ask for clarification if necessary.
+
+Whenever you have a new draft ready, push the changes to your fork and add a comment to the pull request mentioning the Gradle Guides team, saying what type of review you would like. The pull request will update automatically and the review will continue until both sides are happy with the result.
+
+You'll find your guide on the https://guides.gradle.org/[Gradle Guides site] soon after the pull request is accepted and merged. Well done and thank you for the valuable contribution!
 
 == Summary
 
-That's it! You've worked through the steps necessary to create a Getting Started Guide. We hope you've found the process a pleasure and wish you all the best in your writing. Thanks in advance for your contribution!
+In this guide, you learned how to:
+
+ - Submit a proposal for a new Gradle Guide
+ - Fork and clone the new guide's repository
+ - Work on the guide's content according to style guidelines
+ - Initiate a review of your guide
+
+Now that you have some experience with it, we hope that you're inspired to contribute more guides in the future!
 
 == Help improve this guide
 
-Have feedback or a question? Found a typo? Like all Gradle guides, help is just a GitHub Issue away. Please add an issue or pull request to the https://github.com/gradle/build-tool-web/[gradle/build-tool-web] and we'll get back to you.
+Have feedback or a question? Found a typo? Like all Gradle guides, help is just a GitHub Issue away. Please add an issue or pull request to https://github.com/gradle-guides/writing-gradle-guides/[gradle-guides/writing-gradle-guides] and we'll get back to you.


### PR DESCRIPTION
The guide is now designed to work for all types of Gradle guide, not just
Getting Started ones. I have also fleshed out the section on reviewing to make
it clearer what happens and to help ensure a smooth process.

Issue: gradle/guides#8

----

@cbeams @ysb33r I've made a bunch of changes. The main things to check on are:

 - [ ] The title—it's not exactly what was specified but is in line with the GS guides.
 - [ ] Capitalization of Gradle Guides, pull request and Asciidoctor User Manual. I'm least comfortable with _Gradle Guides_, but not enough to argue against it.
 - [ ] Process—is it correct and clear?
 - [ ] Is the suggested slug for the repository suitable? You can find it in the last paragraph.

Any other suggestions also welcome.